### PR TITLE
Debug production build error useLayoutEffect

### DIFF
--- a/src/lib/useIsomorphicLayoutEffect.ts
+++ b/src/lib/useIsomorphicLayoutEffect.ts
@@ -1,5 +1,8 @@
 import { useEffect, useLayoutEffect } from 'react'
 
 // Hook آمن للاستخدام في بيئات مختلفة
+// Defensive check for useLayoutEffect availability
 export const useIsomorphicLayoutEffect = 
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+  typeof window !== 'undefined' && typeof useLayoutEffect !== 'undefined' 
+    ? useLayoutEffect 
+    : useEffect

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,11 +13,13 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+    dedupe: ['react', 'react-dom'],
   },
   optimizeDeps: {
     include: [
       'react',
       'react-dom',
+      'react-dom/client',
       'react-router-dom',
       '@tanstack/react-query',
       '@supabase/supabase-js',
@@ -38,7 +40,12 @@ export default defineConfig({
       output: {
         manualChunks: (id) => {
           if (id.includes('node_modules')) {
-            if (id.includes('react') || id.includes('react-dom')) {
+            // Keep React core together to prevent hook timing issues
+            if (id.includes('react') || id.includes('react-dom') || id.includes('react-dom/client')) {
+              return 'react-vendor'
+            }
+            // Group React ecosystem together with React
+            if (id.includes('react-router') || id.includes('react-query') || id.includes('@tanstack')) {
               return 'react-vendor'
             }
             if (id.includes('supabase')) {
@@ -46,9 +53,6 @@ export default defineConfig({
             }
             if (id.includes('lucide') || id.includes('radix')) {
               return 'ui-vendor'
-            }
-            if (id.includes('@tanstack')) {
-              return 'query-vendor'
             }
             return 'vendor'
           }
@@ -84,6 +88,9 @@ export default defineConfig({
   define: {
     global: 'globalThis',
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
+  },
+  ssr: {
+    noExternal: ['@radix-ui/*', 'lucide-react']
   },
   esbuild: {
     target: 'es2020',


### PR DESCRIPTION
Refactor Vite build configuration and `useIsomorphicLayoutEffect` to resolve `useLayoutEffect` being undefined in production builds.

The `TypeError: Cannot read properties of undefined (reading 'useLayoutEffect')` in production was caused by Vite's manual chunking separating React core from its ecosystem dependencies. This created a race condition where components attempted to use React hooks before React itself was fully loaded, leading to the error. The changes ensure React and its related libraries are bundled together and add defensive checks for hook availability.

---
<a href="https://cursor.com/background-agent?bcId=bc-be0d0b24-feb4-4017-8e5e-1565230a3fbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be0d0b24-feb4-4017-8e5e-1565230a3fbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

