### PR TITLE
Debug production build error useLayoutEffect

### DIFF
--- a/src/lib/useIsomorphicLayoutEffect.ts
+++ b/src/lib/useIsomorphicLayoutEffect.ts
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect } from 'react'
 
-// Hook آمن للاستخدام في بيئات مختلفة
-export const useIsomorphicLayoutEffect = 
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect
+// Use layout effect when DOM is available (prevents SSR warnings)
+const canUseDOM = typeof globalThis !== 'undefined' && Boolean(globalThis?.document)
+
+export const useIsomorphicLayoutEffect = canUseDOM ? useLayoutEffect : useEffect


### PR DESCRIPTION
Update `useIsomorphicLayoutEffect` to use `globalThis?.document` for environment detection to fix a production build error.

The previous `typeof window !== 'undefined'` check, when minified by Vite, caused `useLayoutEffect` to be read from an undefined `React` object in non-DOM environments during the production build, leading to a blank screen. The new check ensures `useLayoutEffect` is only used when the DOM is truly available.

---
<a href="https://cursor.com/background-agent?bcId=bc-665e0116-6faa-49f9-af44-e69aa35b1638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-665e0116-6faa-49f9-af44-e69aa35b1638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

